### PR TITLE
Refactor LSP server to use coroutines via `asyncio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
   "mypy==1.3.0",
   "pip-tools>=6.13.0,<7.0.0",
   "pytest>=7.3.1,<8.0.0",
+  "pytest-asyncio==0.21.0",
   "python-lsp-jsonrpc==1.0.0",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -60,6 +60,10 @@ pygls==1.0.2
 pyproject-hooks==1.0.0
     # via build
 pytest==7.3.2
+    # via
+    #   pytest-asyncio
+    #   ruff-lsp (pyproject.toml)
+pytest-asyncio==0.21.0
     # via ruff-lsp (pyproject.toml)
 python-lsp-jsonrpc==1.0.0
     # via ruff-lsp (pyproject.toml)
@@ -76,7 +80,7 @@ typed-ast==1.5.4
     # via
     #   black
     #   mypy
-typeguard==4.0.0
+typeguard==3.0.2
     # via pygls
 typing-extensions==4.6.3
     # via
@@ -85,6 +89,7 @@ typing-extensions==4.6.3
     #   importlib-metadata
     #   mypy
     #   platformdirs
+    #   pytest-asyncio
     #   ruff-lsp (pyproject.toml)
     #   typeguard
 ujson==5.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pygls==1.0.2
     # via ruff-lsp (pyproject.toml)
 ruff==0.0.272
     # via ruff-lsp (pyproject.toml)
-typeguard==4.0.0
+typeguard==3.0.2
     # via pygls
 typing-extensions==4.6.3
     # via

--- a/ruff_lsp/utils.py
+++ b/ruff_lsp/utils.py
@@ -65,6 +65,6 @@ def version(executable: str) -> str:
 class RunResult:
     """Object to hold result from running tool."""
 
-    def __init__(self, stdout: str, stderr: str):
-        self.stdout: str = stdout
-        self.stderr: str = stderr
+    def __init__(self, stdout: bytes, stderr: bytes):
+        self.stdout: bytes = stdout
+        self.stderr: bytes = stderr

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,7 +20,7 @@ print(x)
 class TestServer(unittest.TestCase):
     maxDiff = None
 
-    def test_linting_example(self):
+    def test_linting_example(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".py") as fp:
             fp.write(CONTENTS.encode())
             fp.flush()
@@ -98,7 +98,7 @@ class TestServer(unittest.TestCase):
                 }
             self.assertEqual(expected, actual)
 
-    def test_no_initialization_options(self):
+    def test_no_initialization_options(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".py") as fp:
             fp.write(CONTENTS.encode())
             fp.flush()


### PR DESCRIPTION
## Summary

The pygls documents recommend using [coroutines](https://pygls.readthedocs.io/en/latest/pages/advanced_usage.html#asynchronous-functions-coroutines) to support cancellation. This PR migrates the LSP to use `asyncio`.

## Test Plan

Created a > 50,000 line Python file, and attempted to make repeated edits before and after.

After this change, there is still some lag when editing:

https://github.com/astral-sh/ruff-lsp/assets/1309177/c7e111c8-3cd2-43cb-8b88-665897a38214

But before this change, the lag is _way_ worse, and you often get out-of-order events!

https://github.com/astral-sh/ruff-lsp/assets/1309177/6c08333d-3628-4321-99ff-b856c6da518e
