### PR TITLE
Remove normalizing newline for source document

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1125,7 +1125,7 @@ async def _run_tool_on_document(
         executable,
         argv,
         cwd=settings["cwd"],
-        source=document.source.replace("\r\n", "\n"),
+        source=document.source,
     )
 
 
@@ -1141,7 +1141,7 @@ async def _run_subcommand_on_document(
         executable,
         argv,
         cwd=settings["cwd"],
-        source=document.source.replace("\r\n", "\n"),
+        source=document.source,
     )
 
 


### PR DESCRIPTION
## Summary

Remove normalizing newline for source document.

## Test Plan

Tested out using CPython codebase with a few files. The diagnostics are being rendered correctly.
