### PR TITLE
Show documentation in LSP output

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -30,6 +30,7 @@ from lsprotocol.types import (
     CodeActionKind,
     CodeActionOptions,
     CodeActionParams,
+    CodeDescription,
     Diagnostic,
     DiagnosticSeverity,
     DiagnosticTag,
@@ -275,8 +276,9 @@ def _parse_output(content: bytes) -> list[Diagnostic]:
         diagnostic = Diagnostic(
             range=Range(start=start, end=end),
             message=check.get("message"),
-            severity=_get_severity(check["code"]),
             code=check["code"],
+            code_description=_get_code_description(check.get("url")),
+            severity=_get_severity(check["code"]),
             source=TOOL_DISPLAY,
             data=DiagnosticData(
                 fix=_parse_fix(check.get("fix")),
@@ -288,6 +290,13 @@ def _parse_output(content: bytes) -> list[Diagnostic]:
         diagnostics.append(diagnostic)
 
     return diagnostics
+
+
+def _get_code_description(url: str | None) -> CodeDescription | None:
+    if url is None:
+        return None
+    else:
+        return CodeDescription(href=url)
 
 
 def _get_tags(code: str) -> list[DiagnosticTag] | None:


### PR DESCRIPTION
## Summary

Looks like this, and links to the docs:

<img width="330" alt="Screen Shot 2023-06-19 at 5 06 52 PM" src="https://github.com/astral-sh/ruff-lsp/assets/1309177/27e92118-1aae-474d-804e-83e0d53682b4">
