### PR TITLE
Updates to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Install dependencies
         run: just install
       - name: Run checks
+        if: ${{ matrix.python-version == "3.10" }}
         run: just check
       - name: Run tests
         run: just test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: just install
       - name: Run checks
-        if: ${{ matrix.python-version == "3.10" }}
+        if: ${{ matrix.python-version == "3.11" }}
         run: just check
       - name: Run tests
         run: just test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: just install
       - name: Run checks
-        if: ${{ matrix.python-version == "3.11" }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: just check
       - name: Run tests
         run: just test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: "3.7"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   release:


### PR DESCRIPTION
## Changes

- Only run lint checks on the latest Python version in CI to unblock #185 
- Add Python 3.11 to CI
- Bump Python version used for releases to 3.11 (previously 3.7 which is now EOL)

## Test plan

Verify that CI runs correctly on this pull request
