### PR TITLE
Use Python 3.11 to build package for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: "3.7"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   release:


### PR DESCRIPTION
Previously we were using Python 3.7 which is EOL
