### PR TITLE
Fix format command

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -684,17 +684,17 @@ if os.environ.get("RUFF_BETA_INTERNAL"):
 
     @LSP_SERVER.feature(TEXT_DOCUMENT_FORMATTING)
     async def format_document(
-        language_server: server.LanguageServer,
-        arguments: DocumentFormattingParams,
+        ls: server.LanguageServer,
+        params: DocumentFormattingParams,
     ) -> list[TextEdit] | None:
-        return await _format_document_impl(language_server, arguments)
+        return await _format_document_impl(ls, params)
 
 
 async def _format_document_impl(
     language_server: server.LanguageServer,
-    arguments: DocumentFormattingParams,
+    params: DocumentFormattingParams,
 ) -> list[TextEdit]:
-    uri = arguments.text_document.uri
+    uri = params.text_document.uri
     document = language_server.workspace.get_document(uri)
     result = await _run_subcommand_on_document(document, args=["format", "-"])
     return _result_to_edits(document, result)


### PR DESCRIPTION
Formatting a document fails in the most recent VS Code extension with the message:

```
missing 1 required positional argument: 'arguments'
```

The issue seems that `pygls` isn't able to figure out that the first argument is the language server, even tough [the documentation](https://pygls.readthedocs.io/en/latest/pages/advanced_usage.html#passing-language-server-instance) mentions that adidng a `LanguageServer` type is sufficient (I tried importing `LanguageServer` and using `: LanguageServer` but with no success). Maybe this only works in sync methods?

I decided not to bother too much and just renamed `language_server` to `ls` and it resolved the problem.

## Test Plan

I linked the extension locally and ran the format document command

https://github.com/astral-sh/ruff-lsp/assets/1203881/5610c88f-4159-420b-938f-d6c083500fb7

The formatting is instantaneous, where black takes about 450ms (noticeable). Range formatting would be nice to remove the *flicker*

