### PR TITLE
Downgrade typeguard to 3.0.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,13 +74,14 @@ tomli==2.0.1
     #   black
     #   build
     #   mypy
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
 typed-ast==1.5.5
     # via
     #   black
     #   mypy
-typeguard==4.1.2
+typeguard==3.0.2
     # via pygls
 typing-extensions==4.7.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pygls==1.0.2
     # via ruff-lsp (pyproject.toml)
 ruff==0.0.287
     # via ruff-lsp (pyproject.toml)
-typeguard==4.1.2
+typeguard==3.0.2
     # via pygls
 typing-extensions==4.7.1
     # via


### PR DESCRIPTION
I'm not sure why dependabot updated this in https://github.com/astral-sh/ruff-lsp/pull/201, but if you try to install our requirements locally, you get a conflict between pygls (which has `^3.0.0`) and typeguard. It passes on CI because we install with `--no-deps`. Huh?
