### PR TITLE
Use `ruff format` (alpha) command for formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/justfile
+++ b/justfile
@@ -9,12 +9,12 @@ install:
   pip install --no-deps -r requirements-dev.txt
 
 fmt:
-  black ./ruff_lsp ./tests
-  ruff --fix ./ruff_lsp ./tests
+  ruff check --fix ./ruff_lsp ./tests
+  ruff format ./ruff_lsp ./tests
 
 check:
-  ruff ./ruff_lsp ./tests
-  black --check ./ruff_lsp ./tests
+  ruff check ./ruff_lsp ./tests
+  ruff format --check ./ruff_lsp ./tests
   mypy ./ruff_lsp ./tests
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "black==23.3.0",
   "mypy==1.4.1",
   "pip-tools>=6.13.0,<7.0.0",
   "pytest>=7.3.1,<8.0.0",
@@ -70,9 +69,6 @@ select = [
   "T203",
 ]
 target-version = "py37"
-
-[tool.black]
-line-length = 88
 
 [tool.mypy]
 files = ["ruff_lsp", "tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,16 +8,12 @@ attrs==23.1.0
     # via
     #   cattrs
     #   lsprotocol
-black==23.3.0
-    # via ruff-lsp (pyproject.toml)
-build==0.10.0
+build==1.0.0
     # via pip-tools
 cattrs==23.1.2
     # via lsprotocol
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 exceptiongroup==1.1.3
     # via
     #   cattrs
@@ -39,20 +35,13 @@ lsprotocol==2023.0.0a3
 mypy==1.4.1
     # via ruff-lsp (pyproject.toml)
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
+    # via mypy
 packaging==23.1
     # via
-    #   black
     #   build
     #   pytest
-pathspec==0.11.2
-    # via black
 pip-tools==6.14.0
     # via ruff-lsp (pyproject.toml)
-platformdirs==3.10.0
-    # via black
 pluggy==1.2.0
     # via pytest
 pygls==1.0.2
@@ -71,25 +60,20 @@ ruff==0.0.287
     # via ruff-lsp (pyproject.toml)
 tomli==2.0.1
     # via
-    #   black
     #   build
     #   mypy
     #   pip-tools
     #   pyproject-hooks
     #   pytest
 typed-ast==1.5.5
-    # via
-    #   black
-    #   mypy
+    # via mypy
 typeguard==3.0.2
     # via pygls
 typing-extensions==4.7.1
     # via
-    #   black
     #   cattrs
     #   importlib-metadata
     #   mypy
-    #   platformdirs
     #   pytest-asyncio
     #   ruff-lsp (pyproject.toml)
     #   typeguard


### PR DESCRIPTION
## Summary

This PR transitions the LSP to use Ruff's formatter via the (alpha) `ruff format` command. It's not yet recommended for production use, but it's more than ready for us to use it internally :)
