### PR TITLE
Add a dedicated 'Ruff: Format document' action

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import cast
-
 import pytest
-from lsprotocol.types import (
-    DocumentFormattingParams,
-    FormattingOptions,
-    TextDocumentIdentifier,
-    WorkspaceEdit,
-)
-from pygls import server
 from pygls.workspace import Workspace
 
 from ruff_lsp.server import _format_document_impl
@@ -24,37 +14,15 @@ expected = """x = 1
 """
 
 
-class MockLanguageServer:
-    root: Path
-    applied_edits: list[WorkspaceEdit] = []
-
-    def __init__(self, root):
-        self.root = root
-
-    @property
-    def workspace(self) -> Workspace:
-        return Workspace(str(self.root))
-
-    def apply_edit(self, edit: WorkspaceEdit, _label: str | None = None) -> None:
-        """Currently unused, but we keep it around for future tests."""
-        self.applied_edits.append(edit)
-
-
 @pytest.mark.asyncio
 async def test_format(tmp_path):
     test_file = tmp_path.joinpath("main.py")
     test_file.write_text(original)
     uri = utils.as_uri(str(test_file))
 
-    mock_language_server = MockLanguageServer(tmp_path)
-    dummy_params = DocumentFormattingParams(
-        text_document=TextDocumentIdentifier(uri=uri),
-        options=FormattingOptions(tab_size=4, insert_spaces=True),
-        work_done_token=None,
-    )
+    workspace = Workspace(str(tmp_path))
+    document = workspace.get_document(uri)
 
-    result = await _format_document_impl(
-        cast(server.LanguageServer, mock_language_server), dummy_params
-    )
+    result = await _format_document_impl(document)
     [edit] = result
     assert edit.new_text == expected


### PR DESCRIPTION
## Summary

We have this for lint fixing and import sorting. It seems consistent to have one for formatting too.
