### PR TITLE
Update use of deprecated `workspace.get_document`

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -21,7 +21,7 @@ async def test_format(tmp_path):
     uri = utils.as_uri(str(test_file))
 
     workspace = Workspace(str(tmp_path))
-    document = workspace.get_document(uri)
+    document = workspace.get_text_document(uri)
 
     result = await _format_document_impl(document)
     [edit] = result


### PR DESCRIPTION
Resolves

```
.../astral-sh/ruff-lsp/tests/test_format.py:24: DeprecationWarning: 'workspace.get_document' has been deprecated, use 'workspace.get_text_document' instead
    document = workspace.get_document(uri)
```