### PR TITLE
Always link add dedicated format command

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -718,17 +718,18 @@ async def apply_organize_imports(arguments: tuple[TextDocument]):
     )
 
 
-if RUFF_EXPERIMENTAL_FORMATTER:
+@LSP_SERVER.command("ruff.applyFormat")
+async def apply_format(arguments: tuple[TextDocument]):
+    uri = arguments[0]["uri"]
+    text_document = LSP_SERVER.workspace.get_text_document(uri)
+    results = await _format_document_impl(text_document)
+    LSP_SERVER.apply_edit(
+        _create_workspace_edits(text_document, results),
+        "Ruff: Format document",
+    )
 
-    @LSP_SERVER.command("ruff.applyFormat")
-    async def apply_format(arguments: tuple[TextDocument]):
-        uri = arguments[0]["uri"]
-        text_document = LSP_SERVER.workspace.get_text_document(uri)
-        results = await _format_document_impl(text_document)
-        LSP_SERVER.apply_edit(
-            _create_workspace_edits(text_document, results),
-            "Ruff: Format document",
-        )
+
+if RUFF_EXPERIMENTAL_FORMATTER:
 
     @LSP_SERVER.feature(TEXT_DOCUMENT_FORMATTING)
     async def format_document(


### PR DESCRIPTION
## Summary

We always expose this on the client side, so doing so conditionally within the server can lead to invalid command errors. This action has to be triggered explicitly by the user, so it seems fine to expose it even if Ruff doesn't register itself as a formatter.

Closes https://github.com/astral-sh/ruff-vscode/issues/300.
