### PR TITLE
Run tests against the main branch of Ruff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,8 +86,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
       - name: Install dependencies
-        run: just install
+        run: |
+          pip install -U pip
+          just install
 
       - name: Install test Ruff version from PyPI
         if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }} 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  RUFF_DEV_REVISION = "main"
+
 on:
   push:
     branches: [main]
@@ -46,13 +49,11 @@ jobs:
           # Get the oldest supported version from the pyproject.toml
           OLDEST=$(rg -No '"ruff>=(.*)"' -r '$1' pyproject.toml)
 
-          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\"]"
+          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", ${{ env.RUFF_DEV_REVISION }}]"
           echo "::set-output name=oldest::$OLDEST
-          echo "::set-output name=latest::$LATEST
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}
       oldest: ${{ steps.set-versions.outputs.oldest }}
-      latest: ${{ steps.set-versions.outputs.latest }}
   test:
     name: Test (python-${{ matrix.python-version }}, ruff-${{ matrix.ruff-version }}, ${{ matrix.os }})
     needs: ruff-versions
@@ -81,7 +82,14 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: just install
-      - name: Install test Ruff version
+
+      - name: Install test Ruff version from PyPI
+        if: ${{ matrix.ruff-version != env.RUFF_DEV_REVISION }} 
         run: pip install ruff==${{ matrix.ruff-version }}
+
+      - name: "Install test Ruff version from GitHub"
+        if: ${{ matrix.ruff-version == env.RUFF_DEV_REVISION }}
+        run: pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+
       - name: Run tests
         run: just test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,8 @@ jobs:
       - name: "Install test Ruff version from GitHub"
         if: ${{ matrix.ruff-version == env.RUFF_UNRELEASED_REF }}
         run: |
-          pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+          pip install --force-reinstall git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+          pip show ruff
           ruff version
 
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  RUFF_DEV_REVISION: 'main'
+  RUFF_UNRELEASED_REF: 'main'
 
 on:
   push:
@@ -48,15 +48,15 @@ jobs:
           )
           # Get the oldest supported version from the pyproject.toml
           OLDEST=$(rg -No '"ruff>=(.*)"' -r '$1' pyproject.toml)
-          DEV=${{ env.RUFF_DEV_REVISION }}
+          UNRELEASED=${{ env.RUFF_UNRELEASED_REF }}
 
-          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", \"$DEV\"]"
+          echo "::set-output name=latest::$LATEST"
           echo "::set-output name=oldest::$OLDEST"
-          echo "::set-output name=dev::$DEV"
+          echo "::set-output name=unreleased::$UNRELEASED"
     outputs:
-      versions: ${{ steps.set-versions.outputs.versions }}
+      latest: ${{ steps.set-versions.outputs.latest }}
       oldest: ${{ steps.set-versions.outputs.oldest }}
-      dev: ${{ steps.set-versions.outputs.dev }}
+      unreleased: ${{ steps.set-versions.outputs.unreleased }}
 
   test:
     name: Test (python-${{ matrix.python-version }}, ruff-${{ matrix.ruff-version }}, ${{ matrix.os }})
@@ -65,14 +65,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        ruff-version: ${{ fromJson(needs.ruff-versions.outputs.versions) }}
+        ruff-version:  ${{ needs.ruff-versions.outputs.latest }}
         os: [ubuntu-latest, macos-latest, windows-latest]
 
-        exclude:
-          - os: windows-latest
-            ruff-version: ${{ needs.ruff-versions.outputs.oldest }}
-          - os: macos-latest
-            ruff-version: ${{ needs.ruff-versions.outputs.oldest }}
+        include:
+          - ruff-version: ${{ needs.ruff-versions.outputs.oldest }}
+            os: ubuntu-latest
+            python-version: "3.7"
+          - ruff-version: ${{ needs.ruff-versions.outputs.unreleased }}
+            os: ubuntu-latest
+            python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -88,11 +90,11 @@ jobs:
         run: just install
 
       - name: Install test Ruff version from PyPI
-        if: ${{ matrix.ruff-version != env.RUFF_DEV_REVISION }} 
+        if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }} 
         run: pip install ruff==${{ matrix.ruff-version }}
 
       - name: "Install test Ruff version from GitHub"
-        if: ${{ matrix.ruff-version == env.RUFF_DEV_REVISION }}
+        if: ${{ matrix.ruff-version == env.RUFF_UNRELEASED_REF }}
         run: |
           pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
           ruff version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,7 @@ jobs:
         if: ${{ matrix.ruff-version == env.RUFF_UNRELEASED_REF }}
         run: |
           pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+          which ruff
           ruff version
 
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,10 @@ jobs:
           )
           # Get the oldest supported version from the pyproject.toml
           OLDEST=$(rg -No '"ruff>=(.*)"' -r '$1' pyproject.toml)
+          DEV=${{ env.RUFF_DEV_REVISION }}
 
-          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", \"${{ env.RUFF_DEV_REVISION }}\"]"
-          echo "::set-output name=oldest::$OLDEST
+          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", \"$DEV\"]"
+          echo "::set-output name=oldest::$OLDEST"
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}
       oldest: ${{ steps.set-versions.outputs.oldest }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,12 @@ jobs:
 
           echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", \"$DEV\"]"
           echo "::set-output name=oldest::$OLDEST"
+          echo "::set-output name=dev::$DEV"
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}
       oldest: ${{ steps.set-versions.outputs.oldest }}
+      dev: ${{ steps.set-versions.outputs.dev }}
+
   test:
     name: Test (python-${{ matrix.python-version }}, ruff-${{ matrix.ruff-version }}, ${{ matrix.os }})
     needs: ruff-versions
@@ -90,7 +93,9 @@ jobs:
 
       - name: "Install test Ruff version from GitHub"
         if: ${{ matrix.ruff-version == env.RUFF_DEV_REVISION }}
-        run: pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+        run: |
+          pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+          ruff version
 
       - name: Run tests
         run: just test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           # Get the oldest supported version from the pyproject.toml
           OLDEST=$(rg -No '"ruff>=(.*)"' -r '$1' pyproject.toml)
 
-          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", ${{ env.RUFF_DEV_REVISION }}]"
+          echo "::set-output name=versions::[\"$OLDEST\", \"$LATEST\", \"${{ env.RUFF_DEV_REVISION }}\"]"
           echo "::set-output name=oldest::$OLDEST
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,13 +91,14 @@ jobs:
 
       - name: Install test Ruff version from PyPI
         if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }} 
-        run: pip install ruff==${{ matrix.ruff-version }}
+        run: |
+          pip install ruff==${{ matrix.ruff-version }}
+          ruff --version
 
       - name: "Install test Ruff version from GitHub"
         if: ${{ matrix.ruff-version == env.RUFF_UNRELEASED_REF }}
         run: |
           pip install git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
-          which ruff
           ruff version
 
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,11 +52,11 @@ jobs:
 
           echo "::set-output name=latest::$LATEST"
           echo "::set-output name=oldest::$OLDEST"
-          echo "::set-output name=unreleased::$UNRELEASED"
+          echo "::set-output name=dev::$UNRELEASED"
     outputs:
       latest: ${{ steps.set-versions.outputs.latest }}
       oldest: ${{ steps.set-versions.outputs.oldest }}
-      unreleased: ${{ steps.set-versions.outputs.unreleased }}
+      dev: ${{ steps.set-versions.outputs.dev }}
 
   test:
     name: Test (python-${{ matrix.python-version }}, ruff-${{ matrix.ruff-version }}, ${{ matrix.os }})
@@ -65,14 +65,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        ruff-version: "${{ needs.ruff-versions.outputs.latest }}"
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
+          - ruff-version: ${{ needs.ruff-versions.outputs.latest }}
           - ruff-version: ${{ needs.ruff-versions.outputs.oldest }}
             os: ubuntu-latest
             python-version: "3.7"
-          - ruff-version: ${{ needs.ruff-versions.outputs.unreleased }}
+          - ruff-version: ${{ needs.ruff-versions.outputs.dev }}
             os: ubuntu-latest
             python-version: "3.12"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        ruff-version:  ${{ needs.ruff-versions.outputs.latest }}
+        ruff-version: "${{ needs.ruff-versions.outputs.latest }}"
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  RUFF_DEV_REVISION = "main"
+  RUFF_DEV_REVISION: 'main'
 
 on:
   push:


### PR DESCRIPTION
Adds tests against ruff@main, installed from source.

The test matrix is kind of big here, we could drop Python versions or operating systems (for a subset of the matrix) but I'm not sure what subset is best. Since this repository is relatively calm, it might not hurt to just have a bunch of checks.

Since this depends on us opening a pull request here to notice breakage with ruff, I'm also adding https://github.com/astral-sh/ruff/pull/8016 which runs tests on each change to ruff.