### PR TITLE
Show ruff version on test start

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
+import subprocess
 from pathlib import Path
 
 import pytest
-import subprocess
 from packaging.version import Version
 
-from ruff_lsp.server import _find_ruff_binary, _get_global_defaults, uris, Executable
+from ruff_lsp.server import Executable, _find_ruff_binary, _get_global_defaults, uris
 from ruff_lsp.settings import WorkspaceSettings
 
 
@@ -40,4 +40,4 @@ def pytest_report_header(config):
         )
 
     version = output.replace("ruff ", "")
-    return [f"ruff: {version}"]
+    return [f"ruff-version: {version}"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
 import pytest
+import subprocess
 from packaging.version import Version
 
-from ruff_lsp.server import _find_ruff_binary, _get_global_defaults, uris
+from ruff_lsp.server import _find_ruff_binary, _get_global_defaults, uris, Executable
 from ruff_lsp.settings import WorkspaceSettings
 
 
-@pytest.fixture(scope="session")
-def ruff_version() -> Version:
+def _get_ruff_executable() -> Executable:
     # Use the ruff-lsp directory as the workspace
     workspace_path = str(Path(__file__).parent.parent)
 
@@ -19,4 +19,25 @@ def ruff_version() -> Version:
         workspace=uris.from_fs_path(workspace_path),
     )
 
-    return _find_ruff_binary(settings, version_requirement=None).version
+    return _find_ruff_binary(settings, version_requirement=None)
+
+
+@pytest.fixture(scope="session")
+def ruff_version() -> Version:
+    return _get_ruff_executable().version
+
+
+def pytest_report_header(config):
+    """Add ruff version to pytest header."""
+    executable = _get_ruff_executable()
+
+    # Display the long version if the executable supports it
+    try:
+        output = subprocess.check_output([executable.path, "version"]).decode().strip()
+    except subprocess.CalledProcessError:
+        output = (
+            subprocess.check_output([executable.path, "--version"]).decode().strip()
+        )
+
+    version = output.replace("ruff ", "")
+    return [f"ruff: {version}"]


### PR DESCRIPTION
Uses the long ruff version if supported by the binary.

Useful for testing e.g. https://github.com/astral-sh/ruff-lsp/pull/286 and https://github.com/astral-sh/ruff/pull/8016

```
❯ pytest
======================================================================================================================================================= test session starts ========================================================================================================================================================
platform darwin -- Python 3.7.17, pytest-7.4.2, pluggy-1.2.0
ruff-version: 0.1.1+15 (860ffb954 2023-10-20)
rootdir: /Users/mz/eng/src/astral-sh/ruff-lsp
configfile: pyproject.toml
plugins: typeguard-3.0.2, asyncio-0.21.1, anyio-3.7.1
asyncio: mode=strict
collected 3 items                                                                                                                                                                                                                                                                                                                  

tests/test_format.py .                                                                                                                                                                                                                                                                                                       [ 33%]
tests/test_server.py ..                                                                                                                                                                                                                                                                                                      [100%]

======================================================================================================================================================== 3 passed in 0.68s =========================================================================================================================================================
```