### PR TITLE
feat(ci): add `cache-dependency-path`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,10 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
       - name: Install dependencies
         run: just install
       - name: Run checks
@@ -86,6 +90,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds the `cache-dependency-path` parameter which allows us to explicitly specify files which contain packages. More information can be found on the [docs for actions/setup-python](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages)
