### PR TITLE
Always write empty fixes on Ruff >= 0.1.6

### DIFF
--- a/ruff_lsp/utils.py
+++ b/ruff_lsp/utils.py
@@ -7,7 +7,7 @@ import os.path
 import site
 import subprocess
 import sys
-from typing import Any
+from typing import Any, NamedTuple
 
 from packaging.version import Version
 
@@ -66,10 +66,14 @@ def version(executable: str) -> Version:
     return Version(version)
 
 
-class RunResult:
+class RunResult(NamedTuple):
     """Object to hold result from running tool."""
 
-    def __init__(self, stdout: bytes, stderr: bytes, exit_code: int):
-        self.stdout: bytes = stdout
-        self.stderr: bytes = stderr
-        self.exit_code: int = exit_code
+    stdout: bytes
+    """The stdout of running the executable."""
+
+    stderr: bytes
+    """The stderr of running the executable."""
+
+    exit_code: int
+    """The exit code of running the executable."""


### PR DESCRIPTION
## Summary

We can avoid the safeguard we introduced in https://github.com/astral-sh/ruff-lsp/pull/317 for newer Ruff versions, since Ruff will now avoid writing empty output for excluded files (see: https://github.com/astral-sh/ruff/pull/8596).

Closes https://github.com/astral-sh/ruff-lsp/issues/267.

## Test Plan

I tested this with a local debug build. Now, when I "Fix all" on a non-excluded file with `import os`, it _does_ properly get removed, while running "Format" or "Fix all" on an excluded file leaves the contents untouched.