### PR TITLE
Only surface errors when stderr is present

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -563,7 +563,8 @@ async def _lint_document_impl(document: Document) -> list[Diagnostic]:
     # diagnostics, 1 indicates successful completion with remaining diagnostics,
     # and 2 indicates an error.
     if result.exit_code not in (0, 1):
-        show_error(f"Ruff: Lint failed ({result.stderr.decode('utf-8')})")
+        if result.stderr:
+            show_error(f"Ruff: Lint failed ({result.stderr.decode('utf-8')})")
         return []
 
     return _parse_output(result.stdout) if result.stdout else []
@@ -1110,7 +1111,8 @@ async def apply_format(arguments: tuple[TextDocument]):
 
     # For `ruff format`, 0 indicates successful completion, non-zero indicates an error.
     if result.exit_code != 0:
-        show_error(f"Ruff: Format failed ({result.stderr.decode('utf-8')})")
+        if result.stderr:
+            show_error(f"Ruff: Format failed ({result.stderr.decode('utf-8')})")
         return None
 
     workspace_edit = _result_to_workspace_edit(document, result)
@@ -1132,7 +1134,8 @@ async def format_document(params: DocumentFormattingParams) -> list[TextEdit] | 
 
     # For `ruff format`, 0 indicates successful completion, non-zero indicates an error.
     if result.exit_code != 0:
-        show_error(f"Ruff: Format failed ({result.stderr.decode('utf-8')})")
+        if result.stderr:
+            show_error(f"Ruff: Format failed ({result.stderr.decode('utf-8')})")
         return None
 
     if not VERSION_REQUIREMENT_EMPTY_OUTPUT.contains(
@@ -1167,7 +1170,8 @@ async def _fix_document_impl(
     # diagnostics, 1 indicates successful completion with remaining diagnostics,
     # and 2 indicates an error.
     if result.exit_code not in (0, 1):
-        show_error(f"Ruff: Fix failed ({result.stderr.decode('utf-8')})")
+        if result.stderr:
+            show_error(f"Ruff: Fix failed ({result.stderr.decode('utf-8')})")
         return None
 
     return _result_to_workspace_edit(document, result)


### PR DESCRIPTION
This has the side effect of avoiding syntax errors, for which we shouldn't show a pop-up.
