### PR TITLE
Fix stale link to Ruff fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ fixes. However, unsafe fixes can be applied manually with the "Quick fix" action
 using "Fix all" can be enabled by setting `unsafe-fixes = true` in your Ruff configuration file or adding
 `--unsafe-fixes` flag to the "Lint args" setting.
 
-See the [Ruff fix docs](https://docs.astral.sh/ruff/configuration/#fix-safety) for more details on how fix
+See the [Ruff fix docs](https://docs.astral.sh/ruff/linter/#fix-safety) for more details on how fix
 safety works.
 
 ## Jupyter Notebook Support


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

One-line repair of a stale URL in the README

## Test Plan

N/A because this is a documentation change only.