### PR TITLE
Range formatting support

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1375,6 +1375,7 @@ def _fixed_source_to_edits(
         fixed_source = "".join(fixed_source)
 
     new_source = _match_line_endings(original_source, fixed_source)
+
     if new_source == original_source:
         return []
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -91,13 +91,7 @@ print( "Formatted")
 print ("Not formatted")
 """
 
-    expected = """x   = 1
-
-
-print("Formatted")
-
-print ("Not formatted")
-"""
+    expected = """print("Formatted")\n"""
 
     test_file = tmp_path.joinpath("main.py")
     test_file.write_text(original)
@@ -128,3 +122,6 @@ print ("Not formatted")
             original_source=document.source, fixed_source=result.stdout.decode("utf-8")
         )
         assert edit.new_text == expected
+        assert edit.range == Range(
+            start=Position(line=3, character=0), end=Position(line=5, character=0)
+        )

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -9,6 +9,7 @@ from pygls.workspace import Workspace
 
 from ruff_lsp.server import (
     VERSION_REQUIREMENT_FORMATTER,
+    VERSION_REQUIREMENT_RANGE_FORMATTING,
     Document,
     _fixed_source_to_edits,
     _get_settings_by_document,
@@ -41,7 +42,7 @@ async def test_format(tmp_path, ruff_version: Version):
     )
 
     with handle_unsupported:
-        result = await _run_format_on_document(document, settings)
+        result = await _run_format_on_document(document, settings, None)
         assert result is not None
         assert result.exit_code == 0
         [edit] = _fixed_source_to_edits(
@@ -74,6 +75,56 @@ foo =
     )
 
     with handle_unsupported:
-        result = await _run_format_on_document(document, settings)
+        result = await _run_format_on_document(document, settings, None)
         assert result is not None
         assert result.exit_code == 2
+
+
+@pytest.mark.asyncio
+async def test_format_range(tmp_path, ruff_version: Version):
+    original = """x   = 1
+
+
+
+print( "Formatted")
+
+print ("Not formatted")
+"""
+
+    expected = """x   = 1
+
+
+print("Formatted")
+
+print ("Not formatted")
+"""
+
+    test_file = tmp_path.joinpath("main.py")
+    test_file.write_text(original)
+    uri = utils.as_uri(str(test_file))
+
+    workspace = Workspace(str(tmp_path))
+    document = Document.from_text_document(workspace.get_text_document(uri))
+    settings = _get_settings_by_document(document.path)
+
+    handle_unsupported = (
+        pytest.raises(RuntimeError, match=f"Ruff .* required, but found {ruff_version}")
+        if not VERSION_REQUIREMENT_RANGE_FORMATTING.contains(ruff_version)
+        else nullcontext()
+    )
+
+    with handle_unsupported:
+        result = await _run_format_on_document(
+            document,
+            settings,
+            Range(
+                start=Position(line=1, character=0),
+                end=(Position(line=4, character=19)),
+            ),
+        )
+        assert result is not None
+        assert result.exit_code == 0
+        [edit] = _fixed_source_to_edits(
+            original_source=document.source, fixed_source=result.stdout.decode("utf-8")
+        )
+        assert edit.new_text == expected


### PR DESCRIPTION
## Summary

This PR implements support for range formatting for Python files. It requires https://github.com/astral-sh/ruff/pull/9733

Note to myself: Writing Python is hard :sweat_smile: 

Closes https://github.com/astral-sh/ruff-lsp/issues/116
Closes https://github.com/astral-sh/ruff-vscode/issues/319

## Limitations

Range formatting Notebooks isn't supported because it raises a few interesting questions:

* Should the range be relative to the concatenated cell content? 
* Should the range use a custom notation `cell:offset`
* What if the range falls on the boundary of two cells? 


I feel like implementing range formatting will be straightforward with a Rust LSP because:
* We can make the assumption that only ever a single cell gets formatted (solves some of the problems above)
* We can directly call into the range formatting API without having to find the proper CLI abstractions.


I tried to teach VS Code that Range formatting isn't supported for notebooks by using a `textSelector` but VS code doesn't seem to care :(
That's why the implementation defaults to format the entire cell for now. I'm open to suggestions.


## Test Plan

* Added tests
[Screencast from 2024-01-31 16-11-40.webm](https://github.com/astral-sh/ruff-lsp/assets/1203881/0d935068-b93e-4714-af10-4128aafe58d5)
