### PR TITLE
Narrow Text edits 

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 
 import pytest
+from lsprotocol.types import Position, Range
 from packaging.version import Version
 from pygls.workspace import Workspace
 
@@ -46,7 +47,10 @@ async def test_format(tmp_path, ruff_version: Version):
         [edit] = _fixed_source_to_edits(
             original_source=document.source, fixed_source=result.stdout.decode("utf-8")
         )
-        assert edit.new_text == expected
+        assert edit.new_text == ""
+        assert edit.range == Range(
+            start=Position(line=0, character=0), end=Position(line=1, character=0)
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Try to narrow text edits to changed lines only. The implemented algorithm is very basic. It only trims the common suffix and postfix (line based) but doesn't do any diffing beyond that. 
The idea is to have a fast (with predictable performance) algorithm that at least avoids transmitting the entire formatted file when doing range formatting. 


## Test Plan

I played with range formatting, code fixes, and normal formatting in the VS code extension to verify that it doesn't truncate text.
