### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,9 +41,9 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
-lsprotocol==2023.0.1 \
-    --hash=sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2 \
-    --hash=sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d
+lsprotocol==2023.0.0 \
+    --hash=sha256:c9d92e12a3f4ed9317d3068226592860aab5357d93cf5b2451dc244eee8f35f2 \
+    --hash=sha256:e85fc87ee26c816adca9eb497bb3db1a7c79c477a11563626e712eaccf926a05
     # via
     #   pygls
     #   ruff-lsp (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ importlib-metadata==6.7.0 \
     --hash=sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4 \
     --hash=sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5
     # via attrs
-lsprotocol==2023.0.1 \
-    --hash=sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2 \
-    --hash=sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d
+lsprotocol==2023.0.0 \
+    --hash=sha256:c9d92e12a3f4ed9317d3068226592860aab5357d93cf5b2451dc244eee8f35f2 \
+    --hash=sha256:e85fc87ee26c816adca9eb497bb3db1a7c79c477a11563626e712eaccf926a05
     # via
     #   pygls
     #   ruff-lsp (pyproject.toml)


### PR DESCRIPTION
## Summary

Run `just lock`

## Motivation

Running `pip install` locally fails with 

```
ERROR: Cannot install -r requirements.txt (line 35) and lsprotocol==2023.0.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested lsprotocol==2023.0.1
    pygls 1.2.1 depends on lsprotocol==2023.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
WARNING: There was an error checking the latest version of pip.
(.venv) 
```

(It doesn't matter if I use python 3.11 or 3.7)

The lspprotocol dependency was updated by Dependabot in https://github.com/astral-sh/ruff-lsp/pull/368

I don't know what I'm doing here is right (Python packaging is confusing...), but I feel like `pip install` should work 😆 

## Test Plan

Running `pip install` no longer fails

