### PR TITLE
Update ruff configuration to ruff 0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ path = "ruff_lsp/__init__.py"
 
 [tool.ruff]
 line-length = 88
+target-version = "py37"
+
+[tool.ruff.lint]
 select = [
   "E",
   "F",
@@ -70,7 +73,6 @@ select = [
   "T201",
   "T203",
 ]
-target-version = "py37"
 
 [tool.mypy]
 files = ["ruff_lsp", "tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,8 @@ def _get_ruff_executable() -> Executable:
     # Use the ruff-lsp directory as the workspace
     workspace_path = str(Path(__file__).parent.parent)
 
-    settings = WorkspaceSettings(
-        **_get_global_defaults(),  # type: ignore[misc]
+    settings = WorkspaceSettings(  # type: ignore[misc]
+        **_get_global_defaults(),
         cwd=None,
         workspacePath=workspace_path,
         workspace=uris.from_fs_path(workspace_path),


### PR DESCRIPTION
## Summary

Change our ruff configuration to make it compatible with ruff +0.2

## Test Plan

`just check` no longer emits any warnings
