### PR TITLE
Use `ruff check` instead of `ruff`

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -154,6 +154,7 @@ VERSION_REQUIREMENT_EMPTY_OUTPUT = SpecifierSet(">=0.1.6")
 
 # Arguments provided to every Ruff invocation.
 CHECK_ARGS = [
+    "check",
     "--force-exclude",
     "--no-cache",
     "--no-fix",


### PR DESCRIPTION
## Summary

Use `ruff check` instead of `ruff` for linting. 

## Test Plan

I verified that: 

* ruff-lsp uses `ruff ...` for linting before making the change
* ruff-lsp uses `ruff check ...` after my change
* that diagnostics are still shown after my change
