### PR TITLE
Convert the path LSP setting to a list if it is a string 

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1765,6 +1765,8 @@ def _find_ruff_binary_path(settings: WorkspaceSettings) -> str:
 
     if settings["path"]:
         # 'path' setting takes priority over everything.
+        if isinstance(settings["path"], str):
+            path = [path]
         for path in settings["path"]:
             path = os.path.expanduser(os.path.expandvars(path))
             if os.path.exists(path):


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I ran into a subtle issue today where I provided a single string path:
```lua
 require('lspconfig').ruff_lsp.setup {
   init_options = {
     settings = {
     path = '~/.pyenv/shims/ruff',
```

Which would result in the following error: 

```
PermissionError: [Errno 13] Permission denied: '/'
``` 

This is because we loop over the path in variable, but of course in Python, you can loop over a string and get `/` as the first result

```python
for path in settings["path"]:
```

This change will convert the str to a simple list in case the user provides a single path rather than a list.

## Test Plan

tested locally
