### PR TITLE
Fix nvim-lspconfig configuration anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ including Neovim, Emacs, Sublime Text, and more.
 To use `ruff-lsp` with Neovim, follow these steps:
 
 1. Install `ruff-lsp` from PyPI along with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
-2. Set up the Neovim LSP client using the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration) (`:h lspconfig-keybindings`).
+2. Set up the Neovim LSP client using the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#configuration) (`:h lspconfig-keybindings`).
 3. Finally, configure `ruff-lsp` in your `init.lua`:
 
 ```lua


### PR DESCRIPTION
Fix configuration anchor link.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The link to suggested-configuration doesn't exist anymore. This fixes that.

## Test Plan

<!-- How was it tested? -->
