### PR TITLE
Use `macos-13` for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  RUFF_UNRELEASED_REF: 'main'
+  RUFF_UNRELEASED_REF: "main"
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements.txt
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
         include:
           - ruff-version: ${{ needs.ruff-versions.outputs.latest }}
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements.txt
@@ -101,7 +101,7 @@ jobs:
           just install
 
       - name: Install test Ruff version from PyPI
-        if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }} 
+        if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }}
         run: |
           pip install ruff==${{ matrix.ruff-version }}
           ruff --version


### PR DESCRIPTION
## Summary

The `macos-latest` action runner doesn't provide Python 3.7. So, let's pin it to `macos-13` until we remove support for Python 3.7.

## Test Plan

CI
