### PR TITLE
Avoid disable rule comment code action for `E999`

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1016,7 +1016,7 @@ async def code_action(params: CodeActionParams) -> list[CodeAction] | None:
             )
             lines: list[str] | None = None
             for diagnostic in params.context.diagnostics:
-                if diagnostic.source == "Ruff":
+                if diagnostic.source == "Ruff" and diagnostic.code != "E999":
                     noqa_row = cast(DiagnosticData, diagnostic.data).get("noqa_row")
                     if noqa_row is not None:
                         if lines is None:


### PR DESCRIPTION
## Summary

This PR updates the `ruff-lsp` server to avoid generating the "disable for this line" code action for `E999` (syntax error). This is a follow-up to https://github.com/astral-sh/ruff/pull/11901 which does the same for the new server.

## Test Plan

Run it locally and make sure there are no quick fixes in the VS Code menu:

<img width="633" alt="Screenshot 2024-06-19 at 07 31 55" src="https://github.com/astral-sh/ruff-lsp/assets/67177269/b7e799fd-b4d0-4e17-90ef-59bbe6c2ea50">
<img width="1034" alt="Screenshot 2024-06-19 at 07 31 40" src="https://github.com/astral-sh/ruff-lsp/assets/67177269/7175b08f-04d1-405d-979c-49d139679884">

