### PR TITLE
Add `showSyntaxErrors` server setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ the following settings are supported:
 | logLevel                             | `error`  | Sets the tracing level for the extension: `error`, `warn`, `info`, or `debug`.                                                                                                                                                                                     |
 | organizeImports                      | `true`   | Whether to register Ruff as capable of handling `source.organizeImports` actions.                                                                                                                                                                                  |
 | path                                 | `[]`     | Path to a custom `ruff` executable, e.g., `["/path/to/ruff"]`.                                                                                                                                                                                                     |
+| showSyntaxErrors                     | `true`   | Whether to show syntax error diagnostics. _New in Ruff v0.5.0_                                                                                                                                                                                                     |
 
 ## Development
 

--- a/ruff_lsp/settings.py
+++ b/ruff_lsp/settings.py
@@ -49,6 +49,9 @@ class UserSettings(TypedDict, total=False):
     ignoreStandardLibrary: bool
     """Whether to ignore files that are inferred to be part of the standard library."""
 
+    showSyntaxErrors: bool
+    """Whether to show syntax error diagnostics."""
+
     # Deprecated: use `lint.args` instead.
     args: list[str]
     """Additional command-line arguments to pass to `ruff check`."""


### PR DESCRIPTION
## Summary

This PR adds a new `showSyntaxErrors` server setting for https://github.com/astral-sh/ruff/pull/12059 in `ruff-lsp`.

## Test Plan

### VS Code

Requires: https://github.com/astral-sh/ruff-vscode/pull/504

Verified that the VS Code extension is using the bundled `ruff-lsp` and the debug build of `ruff`:
```
2024-06-27 08:47:49.567 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
2024-06-27 08:47:49.820 [info] Using 'path' setting: /Users/dhruv/work/astral/ruff/target/debug/ruff
2024-06-27 08:47:49.827 [info] Inferred version 0.4.10 for: /Users/dhruv/work/astral/ruff/target/debug/ruff
2024-06-27 08:47:49.828 [info] Found ruff 0.4.10 at /Users/dhruv/work/astral/ruff/target/debug/ruff
```

Using the following VS Code config:

```json
{
  "ruff.nativeServer": false,
  "ruff.path": ["/Users/dhruv/work/astral/ruff/target/debug/ruff"],
  "ruff.showSyntaxErrors": false
}
```

First, set `ruff.showSyntaxErrors` to `true`:
<img width="1177" alt="Screenshot 2024-06-27 at 08 34 58" src="https://github.com/astral-sh/ruff/assets/67177269/5d77547a-a908-4a00-8714-7c00784e8679">

And then set it to `false`:
<img width="1185" alt="Screenshot 2024-06-27 at 08 35 19" src="https://github.com/astral-sh/ruff/assets/67177269/9720f089-f10c-420b-a2c1-2bbb2245be35">

### Neovim

Using the following Ruff server config:

```lua
require('lspconfig').ruff_lsp.setup {
  cmd = { '/Users/dhruv/work/astral/ruff-lsp/.venv/bin/ruff-lsp' },
  init_options = {
    settings = {
      path = { '/Users/dhruv/work/astral/ruff/target/debug/ruff' },
      showSyntaxErrors = true,
    },
  },
}
```

First, set `showSyntaxErrors` to `true`:
<img width="1279" alt="Screenshot 2024-06-27 at 08 28 03" src="https://github.com/astral-sh/ruff/assets/67177269/e694e231-91ba-47f8-8e8a-ad2e82b85a45">

And then set it to `false`:
<img width="1284" alt="Screenshot 2024-06-27 at 08 28 20" src="https://github.com/astral-sh/ruff/assets/67177269/25b86a57-02b1-44f7-9f65-cf5fdde93b0c">


