### PR TITLE
Use empty metadata instead of `None` as it's required

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -394,7 +394,7 @@ def _create_notebook_json(notebook_document: NotebookDocument) -> str:
             cells.append(
                 {
                     "cell_type": "code",
-                    "metadata": None,
+                    "metadata": {},
                     "outputs": [],
                     "source": cell_document.source,
                 }
@@ -403,7 +403,7 @@ def _create_notebook_json(notebook_document: NotebookDocument) -> str:
             cells.append(
                 {
                     "cell_type": "markdown",
-                    "metadata": None,
+                    "metadata": {},
                     "source": cell_document.source,
                 }
             )


### PR DESCRIPTION
## Summary

Related to https://github.com/astral-sh/ruff/pull/12864, the cell metadata is actually a required field. We got away with it previously because Ruff used `Value`.
	
