### PR TITLE
Fix single-cell formatting

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -428,7 +428,7 @@ def _create_single_cell_notebook_json(source: str) -> str:
             "cells": [
                 {
                     "cell_type": "code",
-                    "metadata": None,
+                    "metadata": {},
                     "outputs": [],
                     "source": source,
                 }


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/12864 changed ruff to respect the language specified in `cell.metadata` when determining Python cells. To do so, the PR added the new `cell.metadata` field and made it required as specified in the [specification](https://ipython.org/ipython-doc/3/notebook/nbformat.html#cell-types). 


https://github.com/astral-sh/ruff-lsp/pull/485 patched ruff-lsp to send an empty dict for `cell.metadata` but we, unfortunately, missed updating the JSON for a single cell document that is used by the formatter. This PR fixes this.

Fixes https://github.com/astral-sh/ruff-vscode/issues/617



## Test Plan

I tested that formatting notebooks is working as expected.
