### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 [![image](https://img.shields.io/pypi/pyversions/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
 [![Actions status](https://github.com/astral-sh/ruff-lsp/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff-lsp/actions)
 
+> [!WARNING]
+>
+> **`ruff-lsp` is deprecated. Please switch to the native language server
+> (`ruff server`). Refer to the [migration
+> guide](https://docs.astral.sh/ruff/editors/migration/) on how to migrate the
+> settings and [setup guide](https://docs.astral.sh/ruff/editors/setup/) for
+> editor-specific setup instructions.**
+
 > [!NOTE]
 >
 > **As of Ruff v0.4.5, Ruff ships with a built-in language server written in Rust: ⚡ `ruff server` ⚡**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 > [!WARNING]
 >
 > **`ruff-lsp` is deprecated. Please switch to the native language server
-> (`ruff server`). Refer to the [migration
+> (`ruff server`). Refer to the [setup
+> guide](https://docs.astral.sh/ruff/editors/setup/) on how to set up the
+> native language server and the [migration
 > guide](https://docs.astral.sh/ruff/editors/migration/) on how to migrate the
-> settings and [setup guide](https://docs.astral.sh/ruff/editors/setup/) for
-> editor-specific setup instructions.**
+> settings.**
 
 # ruff-lsp
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# ruff-lsp
-
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![image](https://img.shields.io/pypi/v/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
-[![image](https://img.shields.io/pypi/l/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
-[![image](https://img.shields.io/pypi/pyversions/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
-[![Actions status](https://github.com/astral-sh/ruff-lsp/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff-lsp/actions)
-
 > [!WARNING]
 >
 > **`ruff-lsp` is deprecated. Please switch to the native language server
@@ -13,6 +5,14 @@
 > guide](https://docs.astral.sh/ruff/editors/migration/) on how to migrate the
 > settings and [setup guide](https://docs.astral.sh/ruff/editors/setup/) for
 > editor-specific setup instructions.**
+
+# ruff-lsp
+
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![image](https://img.shields.io/pypi/v/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
+[![image](https://img.shields.io/pypi/l/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
+[![image](https://img.shields.io/pypi/pyversions/ruff-lsp.svg)](https://pypi.python.org/pypi/ruff-lsp)
+[![Actions status](https://github.com/astral-sh/ruff-lsp/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff-lsp/actions)
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 > native language server and the [migration
 > guide](https://docs.astral.sh/ruff/editors/migration/) on how to migrate the
 > settings.**
+>
+> **Feel free to comment on the [GitHub
+> discussion](https://github.com/astral-sh/ruff/discussions/15991) to ask
+> questions or share feedback.**
 
 # ruff-lsp
 

--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1570,6 +1570,15 @@ async def run_path(
 @LSP_SERVER.feature(INITIALIZE)
 def initialize(params: InitializeParams) -> None:
     """LSP handler for initialize request."""
+    show_warning(
+        "`ruff-lsp` is deprecated. Please switch to the native language server "
+        "(`ruff server`). Refer to the "
+        "[migration guide](https://docs.astral.sh/ruff/editors/migration/) on how to "
+        "migrate the settings and "
+        "[setup guide](https://docs.astral.sh/ruff/editors/setup/) for editor-specific "
+        "setup instructions."
+    )
+
     # Extract client capabilities.
     CLIENT_CAPABILITIES[CODE_ACTION_RESOLVE] = _supports_code_action_resolve(
         params.capabilities
@@ -1993,6 +2002,12 @@ def show_error(message: str) -> None:
     """Show a pop-up with an error. Only use for critical errors."""
     LSP_SERVER.show_message_log(message, MessageType.Error)
     LSP_SERVER.show_message(message, MessageType.Error)
+
+
+def show_warning(message: str) -> None:
+    """Show a pop-up with a warning."""
+    LSP_SERVER.show_message_log(message, MessageType.Warning)
+    LSP_SERVER.show_message(message, MessageType.Warning)
 
 
 def log_warning(message: str) -> None:

--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -151,6 +151,9 @@ VERSION_REQUIREMENT_RANGE_FORMATTING = SpecifierSet(">=0.2.1")
 VERSION_REQUIREMENT_OUTPUT_FORMAT = SpecifierSet(">=0.0.291")
 # Version requirement after which Ruff avoids writing empty output for excluded files.
 VERSION_REQUIREMENT_EMPTY_OUTPUT = SpecifierSet(">=0.1.6")
+# Version requirement to display the deprecation warning for `ruff-lsp` and start
+# recommending `ruff server` instead.
+VERSION_REQUIREMENT_NATIVE_SERVER = SpecifierSet(">=0.3.5")
 
 # Arguments provided to every Ruff invocation.
 CHECK_ARGS = [
@@ -1570,15 +1573,6 @@ async def run_path(
 @LSP_SERVER.feature(INITIALIZE)
 def initialize(params: InitializeParams) -> None:
     """LSP handler for initialize request."""
-    show_warning(
-        "`ruff-lsp` is deprecated. Please switch to the native language server "
-        "(`ruff server`). Refer to the "
-        "[migration guide](https://docs.astral.sh/ruff/editors/migration/) on how to "
-        "migrate the settings and "
-        "[setup guide](https://docs.astral.sh/ruff/editors/setup/) for editor-specific "
-        "setup instructions."
-    )
-
     # Extract client capabilities.
     CLIENT_CAPABILITIES[CODE_ACTION_RESOLVE] = _supports_code_action_resolve(
         params.capabilities
@@ -1621,6 +1615,24 @@ def initialize(params: InitializeParams) -> None:
         settings = []
 
     _update_workspace_settings(settings)
+
+    # Use the Ruff executable from the first workspace to determine when to show the
+    # deprecation warning.
+    executable = _find_ruff_binary(
+        next(iter(WORKSPACE_SETTINGS.values())), version_requirement=None
+    )
+
+    if VERSION_REQUIREMENT_NATIVE_SERVER.contains(executable.version, prereleases=True):
+        show_warning(
+            "`ruff-lsp` is deprecated. Please switch to the native language server "
+            "(`ruff server`). Refer to the "
+            "[setup guide](https://docs.astral.sh/ruff/editors/setup/) on how to set "
+            "up the native language server and the "
+            "[migration guide](https://docs.astral.sh/ruff/editors/migration/) on how "
+            "to migrate the settings. Feel free to comment on the "
+            "[GitHub discussion](https://github.com/astral-sh/ruff/discussions/15991) "
+            "to ask questions or share feedback."
+        )
 
 
 def _supports_code_action_resolve(capabilities: ClientCapabilities) -> bool:


### PR DESCRIPTION
## Summary

This PR adds a deprecation warning during the initialization request if the `ruff` executable found is `>= 0.3.5`.

Refer to https://github.com/astral-sh/ruff-lsp/pull/520#discussion_r1944412160 for the discussion.

### Preview

**VS Code**

It'll provide a warning notification along with logging the message:

<img width="2560" alt="Screenshot 2025-02-03 at 11 21 29 AM" src="https://github.com/user-attachments/assets/3745399a-ea7c-4f74-9d6f-689ecbd435b5" />

**Neovim**

It seems like Neovim has already deprecated `ruff_lsp` if the user is using [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) (which should be most of the users):

<img width="546" alt="Screenshot 2025-02-03 at 11 31 50 AM" src="https://github.com/user-attachments/assets/59f70e2b-a95e-4022-be61-d87a276a1a93" />

But, regardless, the users should receive the warning if they've configured it to do so:

<img width="1280" alt="Screenshot 2025-02-03 at 11 30 54 AM" src="https://github.com/user-attachments/assets/c824ee80-f836-4dba-8515-694f8b4b6048" />
