### PR TITLE
Avoid deprecation warning if client is VS Code

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1616,10 +1616,7 @@ def initialize(params: InitializeParams) -> None:
 
     _update_workspace_settings(settings)
 
-    if (
-        params.client_info is not None
-        and params.client_info.name == "Visual Studio Code"
-    ):
+    if os.getenv("LS_SHOW_DEPRECATION_WARNING") == "False":
         # The extension is responsible for providing the deprecation warning.
         return
 

--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -1616,23 +1616,23 @@ def initialize(params: InitializeParams) -> None:
 
     _update_workspace_settings(settings)
 
-    # Use the Ruff executable from the first workspace to determine when to show the
-    # deprecation warning.
-    executable = _find_ruff_binary(
-        next(iter(WORKSPACE_SETTINGS.values())), version_requirement=None
-    )
+    if (
+        params.client_info is not None
+        and params.client_info.name == "Visual Studio Code"
+    ):
+        # The extension is responsible for providing the deprecation warning.
+        return
 
-    if VERSION_REQUIREMENT_NATIVE_SERVER.contains(executable.version, prereleases=True):
-        show_warning(
-            "`ruff-lsp` is deprecated. Please switch to the native language server "
-            "(`ruff server`). Refer to the "
-            "[setup guide](https://docs.astral.sh/ruff/editors/setup/) on how to set "
-            "up the native language server and the "
-            "[migration guide](https://docs.astral.sh/ruff/editors/migration/) on how "
-            "to migrate the settings. Feel free to comment on the "
-            "[GitHub discussion](https://github.com/astral-sh/ruff/discussions/15991) "
-            "to ask questions or share feedback."
-        )
+    show_warning(
+        "`ruff-lsp` is deprecated. Please switch to the native language server "
+        "(`ruff server`). Refer to the "
+        "[setup guide](https://docs.astral.sh/ruff/editors/setup/) on how to set "
+        "up the native language server and the "
+        "[migration guide](https://docs.astral.sh/ruff/editors/migration/) on how "
+        "to migrate the settings. Feel free to comment on the "
+        "[GitHub discussion](https://github.com/astral-sh/ruff/discussions/15991) "
+        "to ask questions or share feedback."
+    )
 
 
 def _supports_code_action_resolve(capabilities: ClientCapabilities) -> bool:


### PR DESCRIPTION
## Summary

Related: https://github.com/astral-sh/ruff-vscode/pull/685

This PR removes the deprecation warning for VS Code client and removes the version check as well as it's not needed for other editors.

## Test Plan

While testing https://github.com/astral-sh/ruff-vscode/pull/685 with local `ruff-lsp` on this branch, VS Code should only provides notification from the extension and not the one from `ruff-lsp`.
