### PR TITLE
chore(ci): address CI linting findings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,14 @@ updates:
     schedule:
       interval: "daily"
       time: "12:00"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "12:00"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "12:00"
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check:
     name: Check
@@ -18,6 +20,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.11"
@@ -35,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get install -y ripgrep
@@ -51,7 +57,7 @@ jobs:
           )
           # Get the oldest supported version from the pyproject.toml
           OLDEST=$(rg -No '"ruff>=(.*)"' -r '$1' pyproject.toml)
-          UNRELEASED=${{ env.RUFF_UNRELEASED_REF }}
+          UNRELEASED=${RUFF_UNRELEASED_REF}
 
           echo "::set-output name=latest::$LATEST"
           echo "::set-output name=oldest::$OLDEST"
@@ -85,6 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: ${{ matrix.python-version }}
@@ -102,15 +110,19 @@ jobs:
       - name: Install test Ruff version from PyPI
         if: ${{ matrix.ruff-version != env.RUFF_UNRELEASED_REF }}
         run: |
-          pip install ruff==${{ matrix.ruff-version }}
+          pip install ruff==${RUFF_VERSION}
           ruff --version
+        env:
+          RUFF_VERSION: ${{ matrix.ruff-version }}
 
       - name: "Install test Ruff version from GitHub"
         if: ${{ matrix.ruff-version == env.RUFF_UNRELEASED_REF }}
         run: |
-          pip install --force-reinstall git+https://github.com/astral-sh/ruff@${{ matrix.ruff-version }}
+          pip install --force-reinstall git+https://github.com/astral-sh/ruff@${RUFF_VERSION}
           pip show ruff
           ruff version
+        env:
+          RUFF_VERSION: ${{ matrix.ruff-version }}
 
       - name: Run tests
         run: just test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,11 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.11"
           cache: "pip"
@@ -34,7 +34,7 @@ jobs:
     name: Generate test versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install dependencies
         run: |
           sudo apt-get install -y ripgrep
@@ -81,11 +81,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ jobs:
   release:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,15 @@ on:
 env:
   PYTHON_VERSION: "3.11"
 
+permissions: {}
+
 jobs:
   release:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -20,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: hatch build
       - name: Publish to PyPi
-        if: "startsWith(github.ref, 'refs/tags/')"
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           HATCH_INDEX_USER: __token__
           HATCH_INDEX_AUTH: ${{ secrets.RUFF_LSP_TOKEN }}


### PR DESCRIPTION
## Summary

This uses pinact and zizmor to burn down some CI issues. It also enables Dependabot for GitHub Actions for future automatic actions bumps.

(Pretty low priority I figure, since this repo is deprecated. But I figure it doesn't hurt to have the CI be in good order.)

## Test Plan

See what happens in CI.