### PR TITLE
Disable dependabot for pip dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "12:00"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Renovate doesn't use the correct python version when locking the dependencies. So all PRs need manual updating. 
I don't think this is currently worth our time, given that we don't intend on shipping any new version of ruff-lsp

## Test Plan

